### PR TITLE
Add FixedRulePayload::inputs_count()

### DIFF
--- a/cozo-core/src/data/program.rs
+++ b/cozo-core/src/data/program.rs
@@ -302,6 +302,9 @@ impl MagicFixedRuleApply {
         );
         Ok(rel)
     }
+    pub(crate) fn relations_count(&self) -> usize {
+        self.rule_args.len()
+    }
     pub(crate) fn relation(&self, idx: usize) -> Result<&MagicFixedRuleRuleArg> {
         #[derive(Error, Diagnostic, Debug)]
         #[error("Cannot find a required positional argument at index {idx} for '{rule_name}'")]

--- a/cozo-core/src/fixed_rule/mod.rs
+++ b/cozo-core/src/fixed_rule/mod.rs
@@ -329,6 +329,10 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
 }
 
 impl<'a, 'b> FixedRulePayload<'a, 'b> {
+    /// Get the total number of input relations.
+    pub fn inputs_count(&self) -> usize {
+        self.manifest.relations_count()
+    }
     /// Get the input relation at `idx`.
     pub fn get_input(&self, idx: usize) -> Result<FixedRuleInputRelation<'a, 'b>> {
         let arg_manifest = self.manifest.relation(idx)?;


### PR DESCRIPTION
That’s useful for “variadic fixed rules” that can accept any number of input relations. Unless I’m misunderstanding something, this is an easy addition that doesn’t break anything.