### PR TITLE
delete `#[swift_bridge(associated_to = DbInstance)]` 

### DIFF
--- a/cozo-lib-swift/src/lib.rs
+++ b/cozo-lib-swift/src/lib.rs
@@ -15,7 +15,6 @@ mod ffi {
 
         fn new_cozo_db(engine: &str, path: &str, options: &str) -> Option<DbInstance>;
 
-        #[swift_bridge(associated_to = DbInstance)]
         fn run_script_str(&self, payload: &str, params: &str) -> String;
         fn export_relations_str(&self, data: &str) -> String;
         fn import_relations_str(&self, data: &str) -> String;


### PR DESCRIPTION
This PR deletes `#[swift_bridge(associated_to = DbInstance)]`.  `#[swift_bridge(associated_to = DbInstance)]` generates a type method associated with `DbInstance`, like so:

```Rust
#[swift_bridge::bridge]
mod ffi {
    extern "Rust" {
        type SomeType;
        //...
        #[swift_bridge(associated_to = SomeType)]
        fn static_method();
        //...
    }
}
```

Will generate the following:

```Swift
class SomeType {
       //...
   static func static_method() {
       //...
   }
       //...
}
```
If you want to know more details, Please see [#179](https://github.com/chinedufn/swift-bridge/issues/179).