### PR TITLE
Add type declaration for typescript users

### DIFF
--- a/cozo-lib-nodejs/index.d.ts
+++ b/cozo-lib-nodejs/index.d.ts
@@ -1,0 +1,73 @@
+declare module "cozo-node" {
+  export class CozoDb {
+    /**
+     * Constructor
+     *
+     * @param engine:  defaults to 'mem', the in-memory non-persistent engine.
+     *                 'sqlite', 'rocksdb' and maybe others are available,
+     *                 depending on compile time flags.
+     * @param path:    path to store the data on disk, defaults to 'data.db',
+     *                 may not be applicable for some engines such as 'mem'
+     * @param options: defaults to {}, ignored by all the engines in the published NodeJS artefact
+     */
+    constructor(engine?: string, path?: string, options?: object);
+
+    /**
+     * You must call this method for any database you no longer want to use:
+     * otherwise the native resources associated with it may linger for as
+     * long as your program runs. Simply `delete` the variable is not enough.
+     */
+    close(): void;
+
+    /**
+     * Runs a query
+     *
+     * @param script: the query
+     * @param params: the parameters as key-value pairs, defaults to {}
+     */
+    run(script: string, params?: Record<string, any>): Promise<any>;
+
+    /**
+     * Export several relations
+     *
+     * @param relations:  names of relations to export, in an array.
+     */
+    exportRelations(relations: Array<string>): Promise<any>;
+
+    /**
+     * Import several relations.
+     *
+     * Note that triggers are _not_ run for the relations, if any exists.
+     * If you need to activate triggers, use queries with parameters.
+     *
+     * @param data: in the same form as returned by `exportRelations`. The relations
+     *              must already exist in the database.
+     */
+    importRelations(data: object): Promise<object>;
+
+    /**
+     * Backup database
+     *
+     * @param path: path to file to store the backup.
+     */
+    backup(path: string): Promise<any>;
+
+    /**
+     * Restore from a backup. Will fail if the current database already contains data.
+     *
+     * @param path: path to the backup file.
+     */
+    restore(path: string): Promise<object>;
+
+    /**
+     * Import several relations from a backup. The relations must already exist in the database.
+     *
+     * Note that triggers are _not_ run for the relations, if any exists.
+     * If you need to activate triggers, use queries with parameters.
+     *
+     * @param path: path to the backup file.
+     * @param rels: the relations to import.
+     */
+    importRelationsFromBackup(path: string, rels: Array<string>): Promise<any>;
+  }
+}

--- a/cozo-lib-nodejs/package.json
+++ b/cozo-lib-nodejs/package.json
@@ -3,8 +3,10 @@
   "version": "0.6.0",
   "description": "Cozo database for NodeJS",
   "main": "index",
+  "types": "index.d.ts",
   "files": [
     "index.js",
+    "index.d.ts",
     "LICENSE.txt"
   ],
   "binary": {


### PR DESCRIPTION
Hi @zh217, thanks for the amazing work! I thought it might be a "low hanging fruit" to add typescript support, hence this PR.

From the library consumers' point view, this change would allow them to import the library in TypeScript. The library is currently not usable by typescript out-of-the-box due to lack of typing files.

From the maintainer's (your) point view, this change implies the added liability for you to keep the [documentation markdown](https://github.com/cozodb/cozo/blob/main/cozo-lib-nodejs/README.md#basic-api) (all languages) and the `index.d.ts` typing file in sync. An alternative approach is to combine `index.js` + `index.d.ts` into a single `index.ts` file, but that is a bigger change and requires new toolchain.

I'm happy to make small adjustments based on your needs. It is also ok if you want to dismiss this PR. It literally took me 5 minutes.


