### PR TITLE
Wasm demo improvements

### DIFF
--- a/cozo-lib-wasm/wasm-react-demo/src/App.js
+++ b/cozo-lib-wasm/wasm-react-demo/src/App.js
@@ -6,11 +6,11 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import './App.css';
 import {
     Button,
     Checkbox,
     Classes,
+    Colors,
     Dialog,
     FileInput,
     InputGroup,
@@ -19,11 +19,13 @@ import {
     TextArea,
     Toaster
 } from "@blueprintjs/core";
-import {Cell, Column, Table2} from "@blueprintjs/table";
-import React, {useEffect, useState} from "react";
-import init, {CozoDb} from "cozo-lib-wasm";
-import {parse} from "ansicolor";
-import {saveAs} from 'file-saver';
+import { Cell, Column, Table2 } from "@blueprintjs/table";
+import { parse } from "ansicolor";
+import init, { CozoDb } from "cozo-lib-wasm";
+import { saveAs } from 'file-saver';
+import React, { useEffect, useState } from "react";
+import './App.css';
+import { useBlueprintThemeClassName, usePreferredColorScheme } from './hooks/use-color-scheme';
 
 
 function App() {
@@ -43,6 +45,9 @@ function App() {
             setDb(db);
         })
     }, []);
+
+    const colorScheme = usePreferredColorScheme();
+    useBlueprintThemeClassName(colorScheme);
 
     const renderCell = (colIdx) => (rowIdx) => <Cell>
         {displayValue(queryResults.rows[rowIdx][colIdx])}
@@ -70,7 +75,7 @@ function App() {
         if (typeof v === 'string') {
             return v
         } else {
-            return <span style={{color: "#184A90"}}>{JSON.stringify(v)}</span>
+            return <span style={{color: colorScheme === "light" ? Colors.BLUE2 : Colors.BLUE5}}>{JSON.stringify(v)}</span>
         }
     }
 
@@ -134,7 +139,6 @@ function App() {
                 <div style={{display: 'flex'}}>
                     <TextArea
                         autoFocus
-                        spellCheck="false"
                         placeholder="Type query, SHIFT + Enter to run"
                         id="query-box"
                         className="bp4-fill"
@@ -143,6 +147,7 @@ function App() {
                         intent={Intent.PRIMARY}
                         onChange={e => setQueryText(e.target.value)}
                         onKeyDown={handleKeyDown}
+                        spellCheck="false"
                         value={queryText}
                     />
                     {showParams && <TextArea
@@ -152,6 +157,7 @@ function App() {
                         large={true}
                         onChange={e => setParams(e.target.value)}
                         onKeyDown={handleKeyDown}
+                        spellCheck="false"
                         value={params}
                     />}
                 </div>
@@ -204,7 +210,7 @@ function App() {
             </pre> : null}
             {queryResults ? (queryResults.rows && queryResults.headers ?
                 <Table2
-                    cellRendererDependencies={queryResults.rows}
+                    cellRendererDependencies={[renderCell, ...queryResults.rows]}
                     numRows={queryResults.rows.length}
                 >
                     {queryResults.headers.map((n, idx) => <Column

--- a/cozo-lib-wasm/wasm-react-demo/src/App.js
+++ b/cozo-lib-wasm/wasm-react-demo/src/App.js
@@ -134,6 +134,7 @@ function App() {
                 <div style={{display: 'flex'}}>
                     <TextArea
                         autoFocus
+                        spellCheck="false"
                         placeholder="Type query, SHIFT + Enter to run"
                         id="query-box"
                         className="bp4-fill"

--- a/cozo-lib-wasm/wasm-react-demo/src/hooks/use-color-scheme.js
+++ b/cozo-lib-wasm/wasm-react-demo/src/hooks/use-color-scheme.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Detect user preferred color scheme based on OS/browser settings
+ * @returns {'light' | 'dark'}
+ */
+export function usePreferredColorScheme() {
+  const [colorScheme, setColorScheme] = useState("light");
+
+  useEffect(() => {
+    // reference: https://blueprintjs.com/docs/#core/typography.dark-theme
+    const updateColorScheme = (mediaQueryOrEvent) => setColorScheme(mediaQueryOrEvent.matches ? "dark" : "light");
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    updateColorScheme(mediaQuery);
+
+    mediaQuery.addEventListener("change", updateColorScheme);
+    return () => mediaQuery.removeEventListener("change", updateColorScheme);
+  }, []);
+
+  return colorScheme;
+}
+
+/**
+ * Apply Blueprint design system's recommended theme class name to the body element
+ * @param {'light' | 'dark'} colorScheme
+ */
+export function useBlueprintThemeClassName(colorScheme) {
+  useEffect(() => {
+    // reference: https://blueprintjs.com/docs/#core/typography.dark-theme
+    document.body.classList[colorScheme === "dark" ? "add" : "remove"]("bp4-dark");
+  }, [colorScheme]);
+}

--- a/cozo-lib-wasm/wasm-react-demo/src/hooks/use-color-scheme.js
+++ b/cozo-lib-wasm/wasm-react-demo/src/hooks/use-color-scheme.js
@@ -11,7 +11,9 @@ export function usePreferredColorScheme() {
     // reference: https://blueprintjs.com/docs/#core/typography.dark-theme
     const updateColorScheme = (mediaQueryOrEvent) => setColorScheme(mediaQueryOrEvent.matches ? "dark" : "light");
 
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
+    if (!mediaQuery) return;
+
     updateColorScheme(mediaQuery);
 
     mediaQuery.addEventListener("change", updateColorScheme);

--- a/cozo-lib-wasm/wasm-react-demo/src/index.css
+++ b/cozo-lib-wasm/wasm-react-demo/src/index.css
@@ -6,6 +6,10 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+:root {
+  color-scheme: dark light;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
- Disabled spellcheck on all code input textareas
- Added support for OS/browser default color scheme

Color scheme validation + demo. I tested myself on Edge and Firefox
![color-scheme](https://user-images.githubusercontent.com/1895289/236384620-94492d27-0a3d-45a1-9073-5ad94a840955.gif)


