### PR TITLE
Fix rocksb non optimized build warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ members = [
 [profile.bench]
 lto = true
 debug = true
+
+[profile.dev.package."cozorocks"]
+opt-level = 3


### PR DESCRIPTION
`cargo build` was giving me many of these warnings. This PR enables optimization of `cozorocks` to silence that error.
```
warning: In file included from build_version.cc:3:
warning: In file included from /nix/store/dj5anrpwcn0p6h3xnqyr5mz30fc7l825-gcc-12.2.0/include/c++/12.2.0/memory:63:
warning: In file included from /nix/store/dj5anrpwcn0p6h3xnqyr5mz30fc7l825-gcc-12.2.0/include/c++/12.2.0/bits/stl_algobase.h:59:
warning: In file included from /nix/store/dj5anrpwcn0p6h3xnqyr5mz30fc7l825-gcc-12.2.0/include/c++/12.2.0/x86_64-unknown-linux-gnu/bits/c++config.h:655:
warning: In file included from /nix/store/dj5anrpwcn0p6h3xnqyr5mz30fc7l825-gcc-12.2.0/include/c++/12.2.0/x86_64-unknown-linux-gnu/bits/os_defines.h:39:
warning: /nix/store/bhhb91angi23wsr42apz1in1n9b9ilg3-glibc-2.37-8-dev/include/features.h:413:4: warning: _FORTIFY_SOURCE requires compiling with optimization (-O) [-W#warnings]
warning: #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
warning:    ^
warning: 1 warning generated.
```