### PR TITLE
Check for rayon directly instead of depending on "wasm32". 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cozo"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aho-corasick",
  "approx",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "cozo-bin"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-stream",
  "axum",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "cozo-lib-wasm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "console_error_panic_hook",
  "cozo",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "cozo-node"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cozo",
  "crossbeam",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "cozo-swift"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cozo",
  "swift-bridge",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "cozo_c"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cbindgen",
  "cozo",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "cozo_java"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cozo",
  "jni",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "cozo_py"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cozo",
  "miette",

--- a/cozo-core/src/query/eval.rs
+++ b/cozo-core/src/query/eval.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use itertools::Itertools;
 use log::{debug, trace};
 use miette::Result;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(rayon)]
 use rayon::prelude::*;
 
 use crate::data::aggr::Aggregation;
@@ -181,7 +181,7 @@ impl<'a> SessionTx<'a> {
                     };
                     Ok((k, new_store))
                 };
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(rayon)]
                 {
                     let limiter_enabled = limiter.total.is_some();
                     for res in prog
@@ -206,7 +206,7 @@ impl<'a> SessionTx<'a> {
                         to_merge.insert(k, new_store);
                     }
                 }
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(not(rayon))]
                 {
                     for res in prog.iter().map(execution) {
                         let (k, new_store) = res?;
@@ -255,7 +255,7 @@ impl<'a> SessionTx<'a> {
                     };
                     Ok((k, new_store))
                 };
-                #[cfg(not(target_arch = "wasm32"))]
+                #[cfg(rayon)]
                 {
                     let limiter_enabled = limiter.total.is_some();
                     // entry rules with limiter must execute sequentially in order to get deterministic ordering
@@ -280,7 +280,7 @@ impl<'a> SessionTx<'a> {
                         to_merge.insert(k, new_store);
                     }
                 }
-                #[cfg(target_arch = "wasm32")]
+                #[cfg(not(rayon))]
                 {
                     for res in prog.iter().map(execution) {
                         let (k, new_store) = res?;


### PR DESCRIPTION
Check for rayon directly, where rayon is required, instead of "wasm32" / not("wasm32"). This simplifies feature-set checking and fixes one issue with a source build on OSX.