### PR TITLE
update doc comments for cozo_run_query

### DIFF
--- a/cozo-lib-c/cozo_c.h
+++ b/cozo-lib-c/cozo_c.h
@@ -25,7 +25,7 @@ extern "C" {
  *
  * `engine`:  which storage engine to use, can be "mem", "sqlite" or "rocksdb".
  * `path`:    should contain the UTF-8 encoded path name as a null-terminated C-string.
- * `db_id`:   will contain the id of the database opened.
+ * `db_id`:   will contain the ID of the database opened.
  * `options`: options for the DB constructor: engine dependent.
  *
  * When the function is successful, null pointer is returned,
@@ -37,12 +37,12 @@ char *cozo_open_db(const char *engine, const char *path, const char *options, in
 /**
  * Close a database.
  *
- * `id`: the ID representing the database to close.
+ * `db_id`: the ID representing the database to close.
  *
  * Returns `true` if the database is closed,
  * `false` if it has already been closed, or does not exist.
  */
-bool cozo_close_db(int32_t id);
+bool cozo_close_db(int32_t db_id);
 
 /**
  * Run query against a database.

--- a/cozo-lib-c/cozo_c.h
+++ b/cozo-lib-c/cozo_c.h
@@ -47,14 +47,13 @@ bool cozo_close_db(int32_t db_id);
 /**
  * Run query against a database.
  *
- * `db_id`: the ID representing the database to run the query.
- * `script_raw`: a UTF-8 encoded C-string for the CozoScript to execute.
- * `params_raw`: a UTF-8 encoded C-string for the params of the query,
- *               in JSON format. You must always pass in a valid JSON map,
- *               even if you do not use params in your query
- *               (pass "{}" in this case).
- * `errored`:    will point to `false` if the query is successful,
- *               `true` if an error occurred.
+ * `db_id`:           the ID representing the database to run the query.
+ * `script_raw`:      a UTF-8 encoded C-string for the CozoScript to execute.
+ * `params_raw`:      a UTF-8 encoded C-string for the params of the query,
+ *                    in JSON format. You must always pass in a valid JSON map,
+ *                    even if you do not use params in your query
+ *                    (pass "{}" in this case).
+ * `immutable_query`: whether the query is read-only.
  *
  * Returns a UTF-8-encoded C-string that **must** be freed with `cozo_free_str`.
  * The string contains the JSON return value of the query.

--- a/cozo-lib-c/src/lib.rs
+++ b/cozo-lib-c/src/lib.rs
@@ -91,14 +91,13 @@ pub unsafe extern "C" fn cozo_close_db(db_id: i32) -> bool {
 
 /// Run query against a database.
 ///
-/// `db_id`: the ID representing the database to run the query.
-/// `script_raw`: a UTF-8 encoded C-string for the CozoScript to execute.
-/// `params_raw`: a UTF-8 encoded C-string for the params of the query,
-///               in JSON format. You must always pass in a valid JSON map,
-///               even if you do not use params in your query
-///               (pass "{}" in this case).
-/// `errored`:    will point to `false` if the query is successful,
-///               `true` if an error occurred.
+/// `db_id`:           the ID representing the database to run the query.
+/// `script_raw`:      a UTF-8 encoded C-string for the CozoScript to execute.
+/// `params_raw`:      a UTF-8 encoded C-string for the params of the query,
+///                    in JSON format. You must always pass in a valid JSON map,
+///                    even if you do not use params in your query
+///                    (pass "{}" in this case).
+/// `immutable_query`: whether the query is read-only.
 ///
 /// Returns a UTF-8-encoded C-string that **must** be freed with `cozo_free_str`.
 /// The string contains the JSON return value of the query.

--- a/cozo-lib-c/src/lib.rs
+++ b/cozo-lib-c/src/lib.rs
@@ -34,7 +34,7 @@ lazy_static! {
 ///
 /// `engine`:  which storage engine to use, can be "mem", "sqlite" or "rocksdb".
 /// `path`:    should contain the UTF-8 encoded path name as a null-terminated C-string.
-/// `db_id`:   will contain the id of the database opened.
+/// `db_id`:   will contain the ID of the database opened.
 /// `options`: options for the DB constructor: engine dependent.
 ///
 /// When the function is successful, null pointer is returned,
@@ -76,15 +76,15 @@ pub unsafe extern "C" fn cozo_open_db(
 
 /// Close a database.
 ///
-/// `id`: the ID representing the database to close.
+/// `db_id`: the ID representing the database to close.
 ///
 /// Returns `true` if the database is closed,
 /// `false` if it has already been closed, or does not exist.
 #[no_mangle]
-pub unsafe extern "C" fn cozo_close_db(id: i32) -> bool {
+pub unsafe extern "C" fn cozo_close_db(db_id: i32) -> bool {
     let db = {
         let mut dbs = HANDLES.dbs.lock().unwrap();
-        dbs.remove(&id)
+        dbs.remove(&db_id)
     };
     db.is_some()
 }


### PR DESCRIPTION
The primary purpose of this PR is updating the doc comments for cozo-lib-c's `cozo_run_query`, which made reference to an outdated parameter `errored` and did not document the `immutable_query` parameter.

With my addition of:
```rust
/// `immutable_query`: whether the query is read-only.
```
I hope that my understanding of that parameter's purpose is correct.

In `cozo_close_db` I also changed the database ID parameter name from `id` to `db_id`, for consistency's sake.
