### PR TITLE
Implement IntoIterator for NamedRows

### DIFF
--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -224,6 +224,15 @@ impl NamedRows {
     }
 }
 
+impl IntoIterator for NamedRows {
+    type Item = Tuple;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.rows.into_iter()
+    }
+}
+
 const STATUS_STR: &str = "status";
 const OK_STR: &str = "OK";
 


### PR DESCRIPTION
This is a tiny quality-of-life pull request for using `NamedRows`.

Before, one first had peel the `rows` member of `NamedRows` out of the struct to then call `into_iter()`, which is not necessary since the rows are the only reasonable thing to iterate through for a `NamedRows` object.

So, this PR implements the standard trait of `IntoIterator` for `NamedRows` directly, reducing something like `rows.rows.into_iter()` to `rows.into_iter()`.

Since iterating through rows is very common when handling any query result, this would improve the readability and brevity of code significantly for me (and potentially others). If you have any questions, feel free to comment :)