### PR TITLE
NamedRow into Payload.

### DIFF
--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -75,6 +75,7 @@ pub use crate::runtime::db::evaluate_expressions;
 pub use crate::runtime::db::get_variables;
 pub use crate::runtime::db::Poison;
 pub use crate::runtime::db::ScriptMutability;
+pub use crate::runtime::db::Payload;
 pub use crate::runtime::db::TransactionPayload;
 
 pub(crate) mod data;


### PR DESCRIPTION
Once we have NamedRow (from previous query or construct manually), convert it to Payload to make db changes.

This is similar to the insert/put/update/rm wrappers in pycozo.