### PR TITLE
Fix indexes when join is needed

### DIFF
--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -310,22 +310,19 @@ impl<'a> SessionTx<'a> {
                                 }
                                 middle_vars.push(tv);
                             }
+                            let mut final_joiner_vars = vec![];
                             let middle_joiner_right_vars = mapper
                                 .iter()
                                 .enumerate()
                                 .filter_map(|(idx, orig_idx)| {
                                     if *orig_idx < store.metadata.keys.len() {
+                                        final_joiner_vars.push(right_vars[*orig_idx].clone());
                                         Some(middle_vars[idx].clone())
                                     } else {
                                         None
                                     }
                                 })
                                 .collect_vec();
-
-                            let mut final_joiner_vars = vec![];
-                            for idx in mapper.iter() {
-                                final_joiner_vars.push(right_vars[*idx].clone());
-                            }
 
                             let middle = RelAlgebra::relation(
                                 middle_vars,

--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -314,9 +314,9 @@ impl<'a> SessionTx<'a> {
                                     if let Some(join_idx) = right_joiner_vars_pos_rev[orig_idx] {
                                         // Mark the field as bound, since it is used in the join
                                         not_bound[join_idx] = false;
-                                        // Push the index symbol to the left side
+                                        // Push the joiner symbol to the left side
                                         left_keys.push(prev_joiner_vars[join_idx].clone());
-                                        // Push the joiner symbol to the right side
+                                        // Push the index symbol to the right side
                                         right_keys.push(tv.clone());
                                     }
                                     index_vars.push(tv);

--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -240,6 +240,8 @@ impl<'a> SessionTx<'a> {
                     let mut right_joiner_vars = vec![];
                     // used to split in case we need to join again
                     let mut right_joiner_vars_pos = vec![];
+                    // used to find the right joiner var with the tuple position
+                    let mut right_joiner_vars_pos_rev = vec![None; rel_app.args.len()];
                     // vars introduced by right, regardless of joining
                     let mut right_vars = vec![];
                     // used for choosing indices
@@ -252,6 +254,7 @@ impl<'a> SessionTx<'a> {
                             right_vars.push(rk.clone());
                             right_joiner_vars.push(rk);
                             right_joiner_vars_pos.push(i);
+                            right_joiner_vars_pos_rev[i] = Some(right_joiner_vars.len()-1);
                             join_indices.push(IndexPositionUse::Join)
                         } else {
                             seen_variables.insert(var.clone());
@@ -298,56 +301,76 @@ impl<'a> SessionTx<'a> {
                         }
                         Some((chosen_index, mapper, true)) => {
                             // index-with-join
-                            let mut prev_joiner_first_vars = vec![];
-                            let mut middle_joiner_left_vars = vec![];
-                            let mut middle_vars = vec![];
-                            for i in mapper.iter() {
-                                let tv = gen_symb(right_vars[*i].span);
-                                if let Some(j) = right_joiner_vars_pos.iter().position(|el| el == i)
-                                {
-                                    prev_joiner_first_vars.push(prev_joiner_vars[j].clone());
-                                    middle_joiner_left_vars.push(tv.clone());
-                                }
-                                middle_vars.push(tv);
-                            }
-                            let mut final_joiner_vars = vec![];
-                            let middle_joiner_right_vars = mapper
-                                .iter()
-                                .enumerate()
-                                .filter_map(|(idx, orig_idx)| {
-                                    if *orig_idx < store.metadata.keys.len() {
-                                        final_joiner_vars.push(right_vars[*orig_idx].clone());
-                                        Some(middle_vars[idx].clone())
-                                    } else {
-                                        None
+                            let mut not_bound = vec![true; prev_joiner_vars.len()];
+                            let mut index_vars = vec![];
+                            // Get the index and its keys
+                            {
+                                let mut left_keys = vec![];
+                                let mut right_keys = vec![];
+                                for &orig_idx in mapper.iter() {
+                                    // Create a new symbol for the column in the index relation
+                                    let tv = gen_symb(right_vars[orig_idx].span);
+                                    // Check for the existance of this column among the joiner columns
+                                    if let Some(join_idx) = right_joiner_vars_pos_rev[orig_idx] {
+                                        // Mark the field as bound, since it is used in the join
+                                        not_bound[join_idx] = false;
+                                        // Push the index symbol to the left side
+                                        left_keys.push(prev_joiner_vars[join_idx].clone());
+                                        // Push the joiner symbol to the right side
+                                        right_keys.push(tv.clone());
                                     }
-                                })
-                                .collect_vec();
-
-                            let middle = RelAlgebra::relation(
-                                middle_vars,
-                                chosen_index,
-                                rel_app.span,
-                                rel_app.valid_at,
-                            )?;
-                            ret = ret.join(
-                                middle,
-                                prev_joiner_first_vars,
-                                middle_joiner_left_vars,
-                                rel_app.span,
-                            );
-                            let final_alg = RelAlgebra::relation(
-                                right_vars,
-                                store,
-                                rel_app.span,
-                                rel_app.valid_at,
-                            )?;
-                            ret = ret.join(
-                                final_alg,
-                                middle_joiner_right_vars,
-                                final_joiner_vars,
-                                rel_app.span,
-                            );
+                                    index_vars.push(tv);
+                                }
+                                let index = RelAlgebra::relation(
+                                    index_vars.clone(),
+                                    chosen_index,
+                                    rel_app.span,
+                                    rel_app.valid_at,
+                                )?;
+                                ret = ret.join(
+                                    index,
+                                    left_keys,
+                                    right_keys,
+                                    rel_app.span,
+                                );
+                            }
+                            // Join the index with the original relation
+                            {
+                                let mut left_keys = Vec::with_capacity(store.metadata.keys.len());
+                                let mut right_keys = Vec::with_capacity(store.metadata.keys.len());
+                                for (index_idx, &orig_idx) in mapper.iter().enumerate() {
+                                    if orig_idx < store.metadata.keys.len() {
+                                        // Push the index symbol to the left side
+                                        left_keys.push(index_vars[index_idx].clone());
+                                        // Push the relation symbol to the right side
+                                        right_keys.push(right_vars[orig_idx].clone());
+                                    }
+                                }
+                                let relation = RelAlgebra::relation(
+                                    right_vars,
+                                    store,
+                                    rel_app.span,
+                                    rel_app.valid_at,
+                                )?;
+                                ret = ret.join(
+                                    relation,
+                                    left_keys,
+                                    right_keys,
+                                    rel_app.span,
+                                );
+                            }
+                            // Use the binds that were not used in the join
+                            for (i, nb) in not_bound.into_iter().enumerate() {
+                                if !nb { continue };
+                                let (left, right) = (prev_joiner_vars[i].clone(), right_joiner_vars[i].clone());
+                                ret = ret.filter(Expr::build_equate(
+                                    vec![
+                                        Expr::Binding { var: left, tuple_pos: None },
+                                        Expr::Binding { var: right, tuple_pos: None },
+                                    ],
+                                    rel_app.span,
+                                ))?;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #254 
Fixed the [first query](https://github.com/cozodb/cozo/issues/254#issue-2199023594), with the correct binding of "a" to "**2", where it would previously bind "**1" (which is bound to b) to "**2".
```
 stratum | rule_idx | rule | atom_idx | op                   | ref         | joins_on    | filters/expr | out_relation 
---------+----------+------+----------+----------------------+-------------+-------------+--------------+-------------------
 0       | 0        | "?"  | 6        | "load_stored"        | ":source"   | null        | []           | ["x", "b"] 
 0       | 0        | "?"  | 5        | "load_stored"        | ":target:b" | null        | []           | ["**1", "**2"] 
 0       | 0        | "?"  | 4        | "stored_prefix_join" | null        | {"b":"**1"} | null         | ["b", "**2"] 
 0       | 0        | "?"  | 3        | "load_stored"        | ":target"   | null        | []           | ["a", "c", "**0"] 
 0       | 0        | "?"  | 2        | "stored_prefix_join" | null        | {"**2":"a"} | null         | ["b", "a", "c"] 
 0       | 0        | "?"  | 1        | "reorder"            | null        | null        | null         | ["a", "b", "c"] 
 0       | 0        | "?"  | 0        | "out"                | null        | null        | null         | ["a", "b", "c"] 
```
Fixed the [second query](https://github.com/cozodb/cozo/issues/254#issuecomment-2014096480),with the introduction of the filter, where it would previously ignore the bindings not present in the index.
```
 stratum | rule_idx | rule | atom_idx | op                   | ref      | joins_on     | filters/expr    | out_relation 
---------+----------+------+----------+----------------------+----------+--------------+-----------------+---------------------------
 0       | 0        | "?"  | 10       | "load_stored"        | ":rel"   | null         | []              | ["~1", "a1", "a2"] 
 0       | 0        | "?"  | 9        | "load_stored"        | ":rel:a" | null         | []              | ["**1", "**2"] 
 0       | 0        | "?"  | 8        | "stored_prefix_join" | null     | {"a2":"**1"} | null            | ["a1", "a2", "**2"] 
 0       | 0        | "?"  | 7        | "load_stored"        | ":rel"   | null         | []              | ["~2", "**0", "a3"] 
 0       | 0        | "?"  | 6        | "stored_prefix_join" | null     | {"**2":"~2"} | null            | ["a1", "a2", "a3"] 
 0       | 0        | "?"  | 5        | "load_stored"        | ":rel:a" | null         | []              | ["**5", "**6"] 
 0       | 0        | "?"  | 4        | "stored_prefix_join" | null     | {"a3":"**5"} | null            | ["a1", "a2", "a3", "**6"] 
 0       | 0        | "?"  | 3        | "load_stored"        | ":rel"   | null         | []              | ["~3", "**3", "**4"] 
 0       | 0        | "?"  | 2        | "stored_prefix_join" | null     | {"**6":"~3"} | null            | ["a1", "a2", "a3", "**4"] 
 0       | 0        | "?"  | 1        | "filter"             | null     | null         | ["eq(a1, **4)"] | ["a1", "a2", "a3"] 
 0       | 0        | "?"  | 0        | "out"                | null     | null         | null            | ["a1", "a2", "a3"] 
```

This makes the use of index, when not all fields are available in the index relation, compile down to:
1. A load on the index
2. A join of the index to the  original relation
3. A filter on the bindings that weren't present in the index