### PR TITLE
Fixes 274 - take unbounded if 0 in ReorderSort

### DIFF
--- a/cozo-core/src/fixed_rule/utilities/reorder_sort.rs
+++ b/cozo-core/src/fixed_rule/utilities/reorder_sort.rs
@@ -109,7 +109,7 @@ impl FixedRule for ReorderSort {
                 last = sorter;
             }
 
-            if count > take_plus_skip {
+            if take != 0 && count > take_plus_skip {
                 break;
             }
 


### PR DESCRIPTION
1-line fix proposal, but untested.