### PR TITLE
Expose AST in Rust library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cozo-core-examples"
+version = "0.1.0"
+dependencies = [
+ "cozo",
+]
+
+[[package]]
 name = "cozo-lib-wasm"
 version = "0.7.6"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ members = [
     "cozo-lib-wasm",
     "cozo-lib-swift",
     "cozo-lib-python",
-    "cozo-lib-nodejs"
+    "cozo-lib-nodejs",
+    "cozo-core-examples",
 ]
 
 [profile.bench]

--- a/cozo-core-examples/Cargo.toml
+++ b/cozo-core-examples/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cozo-core-examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+cozo = { version = "0.7.6", path = "../cozo-core", default-features = false, features = [
+    "rayon",
+] }

--- a/cozo-core-examples/src/bin/run.rs
+++ b/cozo-core-examples/src/bin/run.rs
@@ -1,0 +1,10 @@
+use cozo::{DbInstance, ScriptMutability};
+
+fn main() {
+    let db = DbInstance::new("mem", "", Default::default()).unwrap();
+    let script = "?[a] := a in [1, 2, 3]";
+    let result = db
+        .run_script(script, Default::default(), ScriptMutability::Immutable)
+        .unwrap();
+    println!("{:?}", result);
+}

--- a/cozo-core-examples/src/bin/run_ast.rs
+++ b/cozo-core-examples/src/bin/run_ast.rs
@@ -1,0 +1,58 @@
+use std::collections::BTreeMap;
+
+use cozo::{
+    data::{
+        functions::current_validity,
+        program::{InputAtom, InputInlineRule, InputInlineRulesOrFixed, InputProgram, Unification},
+        symb::PROG_ENTRY,
+    },
+    parse::{CozoScript, ImperativeStmt, ImperativeStmtClause},
+    DataValue, DbInstance, Num, ScriptMutability, Symbol,
+};
+
+fn main() {
+    let db = DbInstance::new("mem", "", Default::default()).unwrap();
+    let sym_a = Symbol::new("a", Default::default());
+    let script = CozoScript::Imperative(vec![ImperativeStmt::Program {
+        prog: ImperativeStmtClause {
+            prog: InputProgram {
+                prog: {
+                    let mut p = BTreeMap::new();
+                    p.insert(
+                        Symbol::new(PROG_ENTRY, Default::default()),
+                        InputInlineRulesOrFixed::Rules {
+                            rules: vec![InputInlineRule {
+                                head: vec![sym_a.clone()],
+                                aggr: vec![None],
+                                body: vec![InputAtom::Unification {
+                                    inner: Unification {
+                                        binding: sym_a,
+                                        expr: cozo::Expr::Const {
+                                            val: DataValue::List(vec![
+                                                DataValue::Num(Num::Int(1)),
+                                                DataValue::Num(Num::Int(2)),
+                                                DataValue::Num(Num::Int(3)),
+                                            ]),
+                                            span: Default::default(),
+                                        },
+                                        one_many_unif: true,
+                                        span: Default::default(),
+                                    },
+                                }],
+                                span: Default::default(),
+                            }],
+                        },
+                    );
+                    p
+                },
+                out_opts: Default::default(),
+                disable_magic_rewrite: false,
+            },
+            store_as: None,
+        },
+    }]);
+    let result = db
+        .run_script_ast(script, current_validity(), ScriptMutability::Immutable)
+        .unwrap();
+    println!("{:?}", result);
+}

--- a/cozo-core-examples/src/bin/run_parse_ast.rs
+++ b/cozo-core-examples/src/bin/run_parse_ast.rs
@@ -1,0 +1,14 @@
+use cozo::{data::functions::current_validity, parse::parse_script, DbInstance, ScriptMutability};
+
+fn main() {
+    let db = DbInstance::new("mem", "", Default::default()).unwrap();
+    let script = "?[a] := a in [1, 2, 3]";
+    let cur_vld = current_validity();
+    let script_ast =
+        parse_script(script, &Default::default(), &db.get_fixed_rules(), cur_vld).unwrap();
+    println!("AST: {:?}", script_ast);
+    let result = db
+        .run_script_ast(script_ast, cur_vld, ScriptMutability::Immutable)
+        .unwrap();
+    println!("Result: {:?}", result);
+}

--- a/cozo-core/src/data/aggr.rs
+++ b/cozo-core/src/data/aggr.rs
@@ -14,11 +14,11 @@ use rand::prelude::*;
 
 use crate::data::value::DataValue;
 
-pub(crate) struct Aggregation {
-    pub(crate) name: &'static str,
-    pub(crate) is_meet: bool,
-    pub(crate) meet_op: Option<Box<dyn MeetAggrObj>>,
-    pub(crate) normal_op: Option<Box<dyn NormalAggrObj>>,
+pub struct Aggregation {
+    pub name: &'static str,
+    pub is_meet: bool,
+    pub meet_op: Option<Box<dyn MeetAggrObj>>,
+    pub normal_op: Option<Box<dyn NormalAggrObj>>,
 }
 
 impl Clone for Aggregation {
@@ -32,12 +32,12 @@ impl Clone for Aggregation {
     }
 }
 
-pub(crate) trait NormalAggrObj: Send + Sync {
+pub trait NormalAggrObj: Send + Sync {
     fn set(&mut self, value: &DataValue) -> Result<()>;
     fn get(&self) -> Result<DataValue>;
 }
 
-pub(crate) trait MeetAggrObj: Send + Sync {
+pub trait MeetAggrObj: Send + Sync {
     fn init_val(&self) -> DataValue;
     fn update(&self, left: &mut DataValue, right: &DataValue) -> Result<bool>;
 }

--- a/cozo-core/src/data/functions.rs
+++ b/cozo-core/src/data/functions.rs
@@ -2453,7 +2453,7 @@ pub(crate) fn op_now(_args: &[DataValue]) -> Result<DataValue> {
     ))
 }
 
-pub(crate) fn current_validity() -> ValidityTs {
+pub fn current_validity() -> ValidityTs {
     #[cfg(not(target_arch = "wasm32"))]
     let ts_micros = {
         let now = SystemTime::now();

--- a/cozo-core/src/data/mod.rs
+++ b/cozo-core/src/data/mod.rs
@@ -8,12 +8,12 @@
 
 pub(crate) mod aggr;
 pub(crate) mod expr;
-pub(crate) mod functions;
+pub mod functions;
 pub(crate) mod json;
 pub(crate) mod memcmp;
-pub(crate) mod program;
+pub mod program;
 pub(crate) mod relation;
-pub(crate) mod symb;
+pub mod symb;
 pub(crate) mod tuple;
 pub(crate) mod value;
 

--- a/cozo-core/src/data/program.rs
+++ b/cozo-core/src/data/program.rs
@@ -47,14 +47,16 @@ pub(crate) enum ReturnMutation {
 }
 
 #[derive(Clone, PartialEq, Default)]
-pub(crate) struct QueryOutOptions {
-    pub(crate) limit: Option<usize>,
-    pub(crate) offset: Option<usize>,
-    pub(crate) timeout: Option<f64>,
-    pub(crate) sleep: Option<f64>,
-    pub(crate) sorters: Vec<(Symbol, SortDir)>,
-    pub(crate) store_relation: Option<(InputRelationHandle, RelationOp, ReturnMutation)>,
-    pub(crate) assertion: Option<QueryAssertion>,
+pub struct QueryOutOptions {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+    /// Terminate query with an error if it exceeds this many seconds.
+    pub timeout: Option<f64>,
+    /// Sleep after performing the query for this number of seconds. Ignored in WASM.
+    pub sleep: Option<f64>,
+    pub sorters: Vec<(Symbol, SortDir)>,
+    pub store_relation: Option<(InputRelationHandle, RelationOp, ReturnMutation)>,
+    pub assertion: Option<QueryAssertion>,
 }
 
 impl Debug for QueryOutOptions {
@@ -82,16 +84,16 @@ impl Display for QueryOutOptions {
             writeln!(f, "{symb};")?;
         }
         if let Some((
-                        InputRelationHandle {
-                            name,
-                            metadata: StoredRelationMetadata { keys, non_keys },
-                            key_bindings,
-                            dep_bindings,
-                            ..
-                        },
-                        op,
-                        return_mutation,
-                    )) = &self.store_relation
+            InputRelationHandle {
+                name,
+                metadata: StoredRelationMetadata { keys, non_keys },
+                key_bindings,
+                dep_bindings,
+                ..
+            },
+            op,
+            return_mutation,
+        )) = &self.store_relation
         {
             if *return_mutation == ReturnMutation::Returning {
                 writeln!(f, ":returning")?;
@@ -184,13 +186,13 @@ impl QueryOutOptions {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum SortDir {
+pub enum SortDir {
     Asc,
     Dsc,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum RelationOp {
+pub enum RelationOp {
     Create,
     Replace,
     Put,
@@ -219,7 +221,7 @@ impl TempSymbGen {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum InputInlineRulesOrFixed {
+pub enum InputInlineRulesOrFixed {
     Rules { rules: Vec<InputInlineRule> },
     Fixed { fixed: FixedRuleApply },
 }
@@ -249,14 +251,14 @@ impl InputInlineRulesOrFixed {
 }
 
 #[derive(Clone)]
-pub(crate) struct FixedRuleApply {
-    pub(crate) fixed_handle: FixedRuleHandle,
-    pub(crate) rule_args: Vec<FixedRuleArg>,
-    pub(crate) options: Arc<BTreeMap<SmartString<LazyCompact>, Expr>>,
-    pub(crate) head: Vec<Symbol>,
-    pub(crate) arity: usize,
-    pub(crate) span: SourceSpan,
-    pub(crate) fixed_impl: Arc<Box<dyn FixedRule>>,
+pub struct FixedRuleApply {
+    pub fixed_handle: FixedRuleHandle,
+    pub rule_args: Vec<FixedRuleArg>,
+    pub options: Arc<BTreeMap<SmartString<LazyCompact>, Expr>>,
+    pub head: Vec<Symbol>,
+    pub arity: usize,
+    pub span: SourceSpan,
+    pub fixed_impl: Arc<Box<dyn FixedRule>>,
 }
 
 impl FixedRuleApply {
@@ -367,7 +369,7 @@ impl Debug for MagicFixedRuleApply {
 }
 
 #[derive(Clone)]
-pub(crate) enum FixedRuleArg {
+pub enum FixedRuleArg {
     InMem {
         name: Symbol,
         bindings: Vec<Symbol>,
@@ -460,11 +462,15 @@ impl MagicFixedRuleRuleArg {
     }
 }
 
+/// This is a single query, as you'd find between `{}` in a chained query script or with no `{}` in a single query script.
 #[derive(Debug, Clone)]
-pub(crate) struct InputProgram {
-    pub(crate) prog: BTreeMap<Symbol, InputInlineRulesOrFixed>,
-    pub(crate) out_opts: QueryOutOptions,
-    pub(crate) disable_magic_rewrite: bool,
+pub struct InputProgram {
+    /// A mapping of names to rules.  The entry rule must be named `?`.
+    ///
+    /// Ex: `?` in `?[a, b] := ...`
+    pub prog: BTreeMap<Symbol, InputInlineRulesOrFixed>,
+    pub out_opts: QueryOutOptions,
+    pub disable_magic_rewrite: bool,
 }
 
 impl Display for InputProgram {
@@ -504,13 +510,13 @@ impl Display for InputProgram {
                 }
                 InputInlineRulesOrFixed::Fixed {
                     fixed:
-                    FixedRuleApply {
-                        fixed_handle: handle,
-                        rule_args,
-                        options,
-                        head,
-                        ..
-                    },
+                        FixedRuleApply {
+                            fixed_handle: handle,
+                            rule_args,
+                            options,
+                            head,
+                            ..
+                        },
                 } => {
                     write!(f, "{name}")?;
                     f.debug_list().entries(head).finish()?;
@@ -645,7 +651,7 @@ impl InputProgram {
                             inner: rule.body,
                             span: rule.span,
                         }
-                            .disjunctive_normal_form(tx)?;
+                        .disjunctive_normal_form(tx)?;
                         let mut new_head = Vec::with_capacity(rule.head.len());
                         let mut seen: BTreeMap<&Symbol, Vec<Symbol>> = BTreeMap::default();
                         for symb in rule.head.iter() {
@@ -879,11 +885,11 @@ impl MagicSymbol {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct InputInlineRule {
-    pub(crate) head: Vec<Symbol>,
-    pub(crate) aggr: Vec<Option<(Aggregation, Vec<DataValue>)>>,
-    pub(crate) body: Vec<InputAtom>,
-    pub(crate) span: SourceSpan,
+pub struct InputInlineRule {
+    pub head: Vec<Symbol>,
+    pub aggr: Vec<Option<(Aggregation, Vec<DataValue>)>>,
+    pub body: Vec<InputAtom>,
+    pub span: SourceSpan,
 }
 
 #[derive(Debug)]
@@ -923,7 +929,7 @@ impl MagicInlineRule {
 }
 
 #[derive(Clone)]
-pub(crate) enum InputAtom {
+pub enum InputAtom {
     Rule {
         inner: InputRuleApplyAtom,
     },
@@ -948,6 +954,7 @@ pub(crate) enum InputAtom {
         inner: Vec<InputAtom>,
         span: SourceSpan,
     },
+    /// `x = y` or `x in y`
     Unification {
         inner: Unification,
     },
@@ -957,12 +964,12 @@ pub(crate) enum InputAtom {
 }
 
 #[derive(Clone)]
-pub(crate) struct SearchInput {
-    pub(crate) relation: Symbol,
-    pub(crate) index: Symbol,
-    pub(crate) bindings: BTreeMap<SmartString<LazyCompact>, Expr>,
-    pub(crate) parameters: BTreeMap<SmartString<LazyCompact>, Expr>,
-    pub(crate) span: SourceSpan,
+pub struct SearchInput {
+    pub relation: Symbol,
+    pub index: Symbol,
+    pub bindings: BTreeMap<SmartString<LazyCompact>, Expr>,
+    pub parameters: BTreeMap<SmartString<LazyCompact>, Expr>,
+    pub span: SourceSpan,
 }
 
 #[derive(Clone, Debug)]
@@ -1007,7 +1014,7 @@ pub(crate) struct FtsSearch {
 }
 
 impl HnswSearch {
-    pub(crate) fn all_bindings(&self) -> impl Iterator<Item=&Symbol> {
+    pub(crate) fn all_bindings(&self) -> impl Iterator<Item = &Symbol> {
         self.bindings
             .iter()
             .chain(self.bind_field.iter())
@@ -1018,7 +1025,7 @@ impl HnswSearch {
 }
 
 impl FtsSearch {
-    pub(crate) fn all_bindings(&self) -> impl Iterator<Item=&Symbol> {
+    pub(crate) fn all_bindings(&self) -> impl Iterator<Item = &Symbol> {
         self.bindings.iter().chain(self.bind_score.iter())
     }
 }
@@ -1670,12 +1677,12 @@ impl Display for InputAtom {
             }
             InputAtom::Unification {
                 inner:
-                Unification {
-                    binding,
-                    expr,
-                    one_many_unif,
-                    ..
-                },
+                    Unification {
+                        binding,
+                        expr,
+                        one_many_unif,
+                        ..
+                    },
             } => {
                 write!(f, "{binding}")?;
                 if *one_many_unif {
@@ -1743,26 +1750,26 @@ pub(crate) enum MagicAtom {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct InputRuleApplyAtom {
-    pub(crate) name: Symbol,
-    pub(crate) args: Vec<Expr>,
-    pub(crate) span: SourceSpan,
+pub struct InputRuleApplyAtom {
+    pub name: Symbol,
+    pub args: Vec<Expr>,
+    pub span: SourceSpan,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct InputNamedFieldRelationApplyAtom {
-    pub(crate) name: Symbol,
-    pub(crate) args: BTreeMap<SmartString<LazyCompact>, Expr>,
-    pub(crate) valid_at: Option<ValidityTs>,
-    pub(crate) span: SourceSpan,
+pub struct InputNamedFieldRelationApplyAtom {
+    pub name: Symbol,
+    pub args: BTreeMap<SmartString<LazyCompact>, Expr>,
+    pub valid_at: Option<ValidityTs>,
+    pub span: SourceSpan,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct InputRelationApplyAtom {
-    pub(crate) name: Symbol,
-    pub(crate) args: Vec<Expr>,
-    pub(crate) valid_at: Option<ValidityTs>,
-    pub(crate) span: SourceSpan,
+pub struct InputRelationApplyAtom {
+    pub name: Symbol,
+    pub args: Vec<Expr>,
+    pub valid_at: Option<ValidityTs>,
+    pub span: SourceSpan,
 }
 
 #[derive(Clone, Debug)]
@@ -1796,11 +1803,11 @@ pub(crate) struct MagicRelationApplyAtom {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Unification {
-    pub(crate) binding: Symbol,
-    pub(crate) expr: Expr,
-    pub(crate) one_many_unif: bool,
-    pub(crate) span: SourceSpan,
+pub struct Unification {
+    pub binding: Symbol,
+    pub expr: Expr,
+    pub one_many_unif: bool,
+    pub span: SourceSpan,
 }
 
 impl Unification {

--- a/cozo-core/src/data/program.rs
+++ b/cozo-core/src/data/program.rs
@@ -1804,8 +1804,10 @@ pub(crate) struct MagicRelationApplyAtom {
 
 #[derive(Clone, Debug)]
 pub struct Unification {
+    /// Symbol to bind expression to.
     pub binding: Symbol,
     pub expr: Expr,
+    /// If false, `=`, if true, `in`. If true, one row is created for each value in the list in `expr`.
     pub one_many_unif: bool,
     pub span: SourceSpan,
 }

--- a/cozo-core/src/data/symb.rs
+++ b/cozo-core/src/data/symb.rs
@@ -73,7 +73,7 @@ impl Debug for Symbol {
 }
 
 impl Symbol {
-    pub(crate) fn new(name: impl Into<SmartString<LazyCompact>>, span: SourceSpan) -> Self {
+    pub fn new(name: impl Into<SmartString<LazyCompact>>, span: SourceSpan) -> Self {
         Self {
             name: name.into(),
             span,
@@ -104,4 +104,4 @@ impl Symbol {
     }
 }
 
-pub(crate) const PROG_ENTRY: &str = "?";
+pub const PROG_ENTRY: &str = "?";

--- a/cozo-core/src/fts/mod.rs
+++ b/cozo-core/src/fts/mod.rs
@@ -36,10 +36,11 @@ pub(crate) struct FtsIndexManifest {
     pub(crate) filters: Vec<TokenizerConfig>,
 }
 
+#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Serialize, serde_derive::Deserialize)]
-pub(crate) struct TokenizerConfig {
-    pub(crate) name: SmartString<LazyCompact>,
-    pub(crate) args: Vec<DataValue>,
+pub struct TokenizerConfig {
+    pub name: SmartString<LazyCompact>,
+    pub args: Vec<DataValue>,
 }
 
 impl TokenizerConfig {

--- a/cozo-core/src/parse/sys.rs
+++ b/cozo-core/src/parse/sys.rs
@@ -27,7 +27,7 @@ use crate::runtime::relation::AccessLevel;
 use crate::{Expr, FixedRule};
 
 #[derive(Debug)]
-pub(crate) enum SysOp {
+pub enum SysOp {
     Compact,
     ListColumns(Symbol),
     ListIndices(Symbol),
@@ -46,51 +46,52 @@ pub(crate) enum SysOp {
     CreateFtsIndex(FtsIndexConfig),
     CreateMinHashLshIndex(MinHashLshConfig),
     RemoveIndex(Symbol, Symbol),
-    DescribeRelation(Symbol, SmartString<LazyCompact>)
+    DescribeRelation(Symbol, SmartString<LazyCompact>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct FtsIndexConfig {
-    pub(crate) base_relation: SmartString<LazyCompact>,
-    pub(crate) index_name: SmartString<LazyCompact>,
-    pub(crate) extractor: String,
-    pub(crate) tokenizer: TokenizerConfig,
-    pub(crate) filters: Vec<TokenizerConfig>,
+pub struct FtsIndexConfig {
+    pub base_relation: SmartString<LazyCompact>,
+    pub index_name: SmartString<LazyCompact>,
+    pub extractor: String,
+    pub tokenizer: TokenizerConfig,
+    pub filters: Vec<TokenizerConfig>,
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MinHashLshConfig {
+    pub base_relation: SmartString<LazyCompact>,
+    pub index_name: SmartString<LazyCompact>,
+    pub extractor: String,
+    pub tokenizer: TokenizerConfig,
+    pub filters: Vec<TokenizerConfig>,
+    pub n_gram: usize,
+    pub n_perm: usize,
+    pub false_positive_weight: OrderedFloat<f64>,
+    pub false_negative_weight: OrderedFloat<f64>,
+    pub target_threshold: OrderedFloat<f64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct MinHashLshConfig {
-    pub(crate) base_relation: SmartString<LazyCompact>,
-    pub(crate) index_name: SmartString<LazyCompact>,
-    pub(crate) extractor: String,
-    pub(crate) tokenizer: TokenizerConfig,
-    pub(crate) filters: Vec<TokenizerConfig>,
-    pub(crate) n_gram: usize,
-    pub(crate) n_perm: usize,
-    pub(crate) false_positive_weight: OrderedFloat<f64>,
-    pub(crate) false_negative_weight: OrderedFloat<f64>,
-    pub(crate) target_threshold: OrderedFloat<f64>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct HnswIndexConfig {
-    pub(crate) base_relation: SmartString<LazyCompact>,
-    pub(crate) index_name: SmartString<LazyCompact>,
-    pub(crate) vec_dim: usize,
-    pub(crate) dtype: VecElementType,
-    pub(crate) vec_fields: Vec<SmartString<LazyCompact>>,
-    pub(crate) distance: HnswDistance,
-    pub(crate) ef_construction: usize,
-    pub(crate) m_neighbours: usize,
-    pub(crate) index_filter: Option<String>,
-    pub(crate) extend_candidates: bool,
-    pub(crate) keep_pruned_connections: bool,
+pub struct HnswIndexConfig {
+    pub base_relation: SmartString<LazyCompact>,
+    pub index_name: SmartString<LazyCompact>,
+    pub vec_dim: usize,
+    pub dtype: VecElementType,
+    pub vec_fields: Vec<SmartString<LazyCompact>>,
+    pub distance: HnswDistance,
+    pub ef_construction: usize,
+    pub m_neighbours: usize,
+    pub index_filter: Option<String>,
+    pub extend_candidates: bool,
+    pub keep_pruned_connections: bool,
 }
 
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, serde_derive::Serialize, serde_derive::Deserialize,
 )]
-pub(crate) enum HnswDistance {
+pub enum HnswDistance {
     L2,
     InnerProduct,
     Cosine,

--- a/cozo-core/src/runtime/relation.rs
+++ b/cozo-core/src/runtime/relation.rs
@@ -119,7 +119,7 @@ impl RelationHandle {
     Ord,
     PartialOrd,
 )]
-pub(crate) enum AccessLevel {
+pub enum AccessLevel {
     Hidden,
     ReadOnly,
     Protected,


### PR DESCRIPTION
Fixes #224 

- Make all of the AST public, rooted at `CozoScript`

- Make `cozo::parse::parse_script` public

- Add methods `db.run_script_ast` and `db.get_fixed_rules` to db to allow executing ASTs directly. These are used under the hood by the existing methods.

Some of the interfaces are a bit raw, and while it seemed pretty clean to me some of the stuff that's exposed (`FixedRule` traits) could be considered internal, so I explicitly documented `cozo::parse` and the `parse_script` methods as unstable to warn users that they might change in any future release.

Design notes and concerns

- I don't think exposing `get_fixed_rules` is great. The rules are embedded in the AST during parsing and I thought this might be an optimization thing, so I left it.

  A cleaner solution might be to just embed the names in the AST, and have the database look up the fixed rules when translating/executing the query (raising an error if they don't exist at that time).  It'd also make the AST objects more portable so generic functions could return them without knowing which DB backend it'll be used in, and might pave the way to serializing/deserializing scripts as JSON.

  For now though since the performance question is unanswered I think this is good enough.

- Parameters are also inlined.  It means an AST can't be reused with different parameters, but I'm not sure how actually common that is, so I think this is fine.

- Current validity is passed in both during parsing and during execution, and I'm not sure if this is necessary, but I didn't dig too deep.

- Documentation - I left most things undocumented.  A decent amount corresponds to terminology in the online documentation, and I added some docstrings for things that I actually encountered and couldn't figure out at a glance.  I don't think it's practical to document everything atm, and since maintenance isn't super active on this library I don't think it's reasonable to expect everything to be documented from the start.  Incrementally adding documentation as people have questions or make PRs to document should be an OK compromise I think.

- I added a `cozo-core-examples` module, with examples of using `cozo-core`, parsing an AST, and running an AST directly.  The reason I made it a separate module is because `examples` etc inherits the parent dependencies, so it can hide issues with macro dependencies and other things, and having separate dependencies serves as a better reference for users.