### PR TITLE
Fix stored relation prefix_join on key range

### DIFF
--- a/cozo-core/Cargo.toml
+++ b/cozo-core/Cargo.toml
@@ -143,4 +143,4 @@ fast2s = "0.3.1"
 swapvec = "0.3.0"
 
 [dev-dependencies]
-tempfile = "3.14.0" 
+tempfile = "3.14.0"

--- a/cozo-core/src/query/ra.rs
+++ b/cozo-core/src/query/ra.rs
@@ -1178,7 +1178,7 @@ impl StoredWithValidityRA {
                     .collect_vec();
 
                 if !skip_range_check && !self.filters.is_empty() {
-                    let other_bindings = &self.bindings[right_join_indices.len()..];
+                    let other_bindings = &self.bindings[right_join_indices.len()..self.storage.metadata.keys.len()];
                     let (l_bound, u_bound) = match compute_bounds(&self.filters, other_bindings) {
                         Ok(b) => b,
                         _ => (vec![], vec![]),
@@ -1341,7 +1341,7 @@ impl StoredRA {
                 let mut stack = vec![];
 
                 if !skip_range_check && !self.filters.is_empty() {
-                    let other_bindings = &self.bindings[right_join_indices.len()..];
+                    let other_bindings = &self.bindings[right_join_indices.len()..self.storage.metadata.keys.len()];
                     let (l_bound, u_bound) = match compute_bounds(&self.filters, other_bindings) {
                         Ok(b) => b,
                         _ => (vec![], vec![]),


### PR DESCRIPTION
* The stored relation (both with and without validity) was incorrectly using non-key values when seeking for the start key in a range resulting in the first key that should've been returned being skipped.
* For example, in the case of a stored relation defined as `*r{k => v}`, a query for `*r{k, v}, k >= 3` would skip over a key with value 3 because it will do a join with the key encoding of [3, null] where null is for the value of v.
* In the prefix join, only the keys should be considered, not the value columns so truncate the bindings to the length of the keys to exclude values.