### PR TITLE
feat(rocksdb): add memory limit configuration options

### DIFF
--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -59,7 +59,7 @@ pub use runtime::relation::decode_tuple_from_kv;
 pub use runtime::temp_store::RegularTempStore;
 pub use storage::mem::{new_cozo_mem, MemStorage};
 #[cfg(feature = "storage-rocksdb")]
-pub use storage::rocks::{new_cozo_rocksdb, RocksDbStorage};
+pub use storage::rocks::{new_cozo_rocksdb, new_cozo_rocksdb_with_opts, RocksDbOpts, RocksDbStorage};
 #[cfg(feature = "storage-new-rocksdb")]
 pub use storage::newrocks::{new_cozo_newrocksdb, NewRocksDbStorage};
 #[cfg(feature = "storage-sled")]
@@ -144,7 +144,9 @@ impl DbInstance {
     /// some of the engines are available. The `mem` engine is always available.
     ///
     /// `path` is ignored for `mem` and `tikv` engines.
-    /// `options` is ignored for every engine except `tikv`.
+    /// `options` is a JSON string. For `rocksdb`, supported options are:
+    /// * `block_cache_size`: size of the block cache in bytes (default: 0, meaning RocksDB default)
+    /// For `tikv`, see the TiKV documentation.
     #[allow(unused_variables)]
     pub fn new(engine: &str, path: impl AsRef<Path>, options: &str) -> Result<Self> {
         let options = if options.is_empty() { "{}" } else { options };
@@ -153,7 +155,17 @@ impl DbInstance {
             #[cfg(feature = "storage-sqlite")]
             "sqlite" => Self::Sqlite(new_cozo_sqlite(path)?),
             #[cfg(feature = "storage-rocksdb")]
-            "rocksdb" => Self::RocksDb(new_cozo_rocksdb(path)?),
+            "rocksdb" => {
+                #[derive(serde_derive::Deserialize, Default)]
+                struct RocksOpts {
+                    #[serde(default)]
+                    block_cache_size: usize,
+                }
+                let opts: RocksOpts = serde_json::from_str(options).unwrap_or_default();
+                Self::RocksDb(new_cozo_rocksdb_with_opts(path, RocksDbOpts {
+                    block_cache_size: opts.block_cache_size,
+                })?)
+            }
             #[cfg(feature = "storage-new-rocksdb")]
             "newrocksdb" => Self::NewRocksDb(new_cozo_newrocksdb(path)?),
             #[cfg(feature = "storage-sled")]

--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -146,6 +146,9 @@ impl DbInstance {
     /// `path` is ignored for `mem` and `tikv` engines.
     /// `options` is a JSON string. For `rocksdb`, supported options are:
     /// * `block_cache_size`: size of the block cache in bytes (default: 0, meaning RocksDB default)
+    /// * `write_buffer_size`: size of a single memtable in bytes (default: 64MB)
+    /// * `max_write_buffer_number`: max number of memtables (default: 2)
+    /// * `db_write_buffer_size`: total memory budget for all memtables (default: 0, unlimited)
     /// For `tikv`, see the TiKV documentation.
     #[allow(unused_variables)]
     pub fn new(engine: &str, path: impl AsRef<Path>, options: &str) -> Result<Self> {
@@ -160,10 +163,19 @@ impl DbInstance {
                 struct RocksOpts {
                     #[serde(default)]
                     block_cache_size: usize,
+                    #[serde(default)]
+                    write_buffer_size: usize,
+                    #[serde(default)]
+                    max_write_buffer_number: usize,
+                    #[serde(default)]
+                    db_write_buffer_size: usize,
                 }
                 let opts: RocksOpts = serde_json::from_str(options).unwrap_or_default();
                 Self::RocksDb(new_cozo_rocksdb_with_opts(path, RocksDbOpts {
                     block_cache_size: opts.block_cache_size,
+                    write_buffer_size: opts.write_buffer_size,
+                    max_write_buffer_number: opts.max_write_buffer_number,
+                    db_write_buffer_size: opts.db_write_buffer_size,
                 })?)
             }
             #[cfg(feature = "storage-new-rocksdb")]

--- a/cozo-core/src/storage/rocks.rs
+++ b/cozo-core/src/storage/rocks.rs
@@ -28,6 +28,9 @@ const CURRENT_STORAGE_VERSION: u64 = 3;
 #[derive(Default)]
 pub struct RocksDbOpts {
     pub block_cache_size: usize,
+    pub write_buffer_size: usize,
+    pub max_write_buffer_number: usize,
+    pub db_write_buffer_size: usize,
 }
 
 /// Creates a RocksDB database object.
@@ -114,6 +117,15 @@ pub fn new_cozo_rocksdb_with_opts(path: impl AsRef<Path>, opts: RocksDbOpts) -> 
 
     if opts.block_cache_size > 0 {
         db_builder = db_builder.block_cache_size(opts.block_cache_size);
+    }
+    if opts.write_buffer_size > 0 {
+        db_builder = db_builder.write_buffer_size(opts.write_buffer_size);
+    }
+    if opts.max_write_buffer_number > 0 {
+        db_builder = db_builder.max_write_buffer_number(opts.max_write_buffer_number);
+    }
+    if opts.db_write_buffer_size > 0 {
+        db_builder = db_builder.db_write_buffer_size(opts.db_write_buffer_size);
     }
 
     let db = db_builder.build()?;

--- a/cozo-core/src/storage/rocks.rs
+++ b/cozo-core/src/storage/rocks.rs
@@ -25,11 +25,20 @@ use crate::Db;
 const KEY_PREFIX_LEN: usize = 9;
 const CURRENT_STORAGE_VERSION: u64 = 3;
 
+#[derive(Default)]
+pub struct RocksDbOpts {
+    pub block_cache_size: usize,
+}
+
 /// Creates a RocksDB database object.
 /// This is currently the fastest persistent storage and it can
 /// sustain huge concurrency.
 /// Supports concurrent readers and writers.
 pub fn new_cozo_rocksdb(path: impl AsRef<Path>) -> Result<Db<RocksDbStorage>> {
+    new_cozo_rocksdb_with_opts(path, RocksDbOpts::default())
+}
+
+pub fn new_cozo_rocksdb_with_opts(path: impl AsRef<Path>, opts: RocksDbOpts) -> Result<Db<RocksDbStorage>> {
     let builder = DbBuilder::default().path(path.as_ref());
     fs::create_dir_all(path.as_ref()).map_err(|err| {
         BadDbInit(format!(
@@ -96,12 +105,16 @@ pub fn new_cozo_rocksdb(path: impl AsRef<Path>) -> Result<Db<RocksDbStorage>> {
         ""
     };
 
-    let db_builder = builder
+    let mut db_builder = builder
         .create_if_missing(is_new)
         .use_capped_prefix_extractor(true, KEY_PREFIX_LEN)
         .use_bloom_filter(true, 9.9, true)
         .path(store_path)
         .options_path(options_path);
+
+    if opts.block_cache_size > 0 {
+        db_builder = db_builder.block_cache_size(opts.block_cache_size);
+    }
 
     let db = db_builder.build()?;
 

--- a/cozorocks/bridge/db.cpp
+++ b/cozorocks/bridge/db.cpp
@@ -59,7 +59,7 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
     shared_ptr<Cache> cache = nullptr;
 
     if (opts.block_cache_size > 0) {
-        cache = NewLRUCache(1 * 1024 * 1024 * 1024);
+        cache = NewLRUCache(opts.block_cache_size);
     }
 
     if (!opts.options_path.empty()) {
@@ -77,13 +77,18 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
         if (cache != nullptr) {
             for (size_t i = 0; i < loaded_cf_descs.size(); ++i) {
                 auto* loaded_bbt_opt =
-                        loaded_cf_descs[0]
+                        loaded_cf_descs[i]
                                 .options.table_factory->GetOptions<BlockBasedTableOptions>();
                 loaded_bbt_opt->block_cache = cache;
             }
         }
 
         options = Options(loaded_db_opt, loaded_cf_descs[0].options);
+    } else if (cache != nullptr) {
+        auto* bbt_opt = options.table_factory->GetOptions<BlockBasedTableOptions>();
+        if (bbt_opt != nullptr) {
+            bbt_opt->block_cache = cache;
+        }
     }
 
     if (opts.prepare_for_bulk_load) {
@@ -110,6 +115,9 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
         BlockBasedTableOptions table_options;
         table_options.filter_policy.reset(NewBloomFilterPolicy(opts.bloom_filter_bits_per_key, false));
         table_options.whole_key_filtering = opts.bloom_filter_whole_key_filtering;
+        if (cache != nullptr) {
+            table_options.block_cache = cache;
+        }
         options.table_factory.reset(NewBlockBasedTableFactory(table_options));
     }
     if (opts.use_capped_prefix_extractor) {

--- a/cozorocks/bridge/db.cpp
+++ b/cozorocks/bridge/db.cpp
@@ -125,6 +125,10 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
     }
     if (opts.use_bloom_filter) {
         BlockBasedTableOptions table_options;
+        table_options.block_size = 16 * 1024;
+        table_options.cache_index_and_filter_blocks = true;
+        table_options.pin_l0_filter_and_index_blocks_in_cache = true;
+        table_options.format_version = 5;
         table_options.filter_policy.reset(NewBloomFilterPolicy(opts.bloom_filter_bits_per_key, false));
         table_options.whole_key_filtering = opts.bloom_filter_whole_key_filtering;
         if (cache != nullptr) {

--- a/cozorocks/bridge/db.cpp
+++ b/cozorocks/bridge/db.cpp
@@ -102,6 +102,18 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
     }
     options.create_if_missing = opts.create_if_missing;
     options.paranoid_checks = opts.paranoid_checks;
+
+    // Memory limit options for write buffers (memtables)
+    if (opts.write_buffer_size > 0) {
+        options.write_buffer_size = opts.write_buffer_size;
+    }
+    if (opts.max_write_buffer_number > 0) {
+        options.max_write_buffer_number = static_cast<int>(opts.max_write_buffer_number);
+    }
+    if (opts.db_write_buffer_size > 0) {
+        options.db_write_buffer_size = opts.db_write_buffer_size;
+    }
+
     if (opts.enable_blob_files) {
         options.enable_blob_files = true;
 

--- a/cozorocks/src/bridge/db.rs
+++ b/cozorocks/src/bridge/db.rs
@@ -54,6 +54,9 @@ impl Default for DbOpts {
             fixed_prefix_extractor_len: 0,
             destroy_on_exit: false,
             block_cache_size: 0,
+            write_buffer_size: 0,
+            max_write_buffer_number: 0,
+            db_write_buffer_size: 0,
         }
     }
 }
@@ -123,6 +126,18 @@ impl DbBuilder {
     }
     pub fn block_cache_size(mut self, size: usize) -> Self {
         self.opts.block_cache_size = size;
+        self
+    }
+    pub fn write_buffer_size(mut self, size: usize) -> Self {
+        self.opts.write_buffer_size = size;
+        self
+    }
+    pub fn max_write_buffer_number(mut self, num: usize) -> Self {
+        self.opts.max_write_buffer_number = num;
+        self
+    }
+    pub fn db_write_buffer_size(mut self, size: usize) -> Self {
+        self.opts.db_write_buffer_size = size;
         self
     }
     pub fn build(self) -> Result<RocksDb, RocksDbStatus> {

--- a/cozorocks/src/bridge/db.rs
+++ b/cozorocks/src/bridge/db.rs
@@ -121,6 +121,10 @@ impl DbBuilder {
         self.opts.fixed_prefix_extractor_len = len;
         self
     }
+    pub fn block_cache_size(mut self, size: usize) -> Self {
+        self.opts.block_cache_size = size;
+        self
+    }
     pub fn build(self) -> Result<RocksDb, RocksDbStatus> {
         let mut status = RocksDbStatus::default();
 

--- a/cozorocks/src/bridge/mod.rs
+++ b/cozorocks/src/bridge/mod.rs
@@ -41,6 +41,9 @@ pub(crate) mod ffi {
         pub fixed_prefix_extractor_len: usize,
         pub destroy_on_exit: bool,
         pub block_cache_size: usize,
+        pub write_buffer_size: usize,
+        pub max_write_buffer_number: usize,
+        pub db_write_buffer_size: usize,
     }
 
     #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
  Add RocksDB memory configuration options to prevent unbounded memory growth:

  - `block_cache_size`: Limit LRU block cache (read cache)
  - `write_buffer_size`: Size per memtable
  - `max_write_buffer_number`: Max concurrent memtables
  - `db_write_buffer_size`: Total memtable memory budget

  ## Motivation
  Without these limits, RocksDB can consume all available memory during heavy write workloads, leading to OOM kills on containers.

  ## Usage
  ```json
  {
    "block_cache_size": 2147483648,
    "write_buffer_size": 67108864,
    "max_write_buffer_number": 4,
    "db_write_buffer_size": 536870912
  }
